### PR TITLE
lib: use explicit types

### DIFF
--- a/lib/chips_to_bits_fb_impl.cc
+++ b/lib/chips_to_bits_fb_impl.cc
@@ -42,7 +42,8 @@ namespace gr {
     chips_to_bits_fb_impl::chips_to_bits_fb_impl(std::vector< std::vector< float > > chip_seq)
       : gr::sync_decimator("chips_to_bits_fb",
               gr::io_signature::make(1,1, sizeof(float)),
-              gr::io_signature::make(1,1, sizeof(unsigned char)), chip_seq[0].size()/std::log2(chip_seq.size())),
+              gr::io_signature::make(1,1, sizeof(unsigned char)),
+              (unsigned)(((float)chip_seq[0].size())/std::log2((float)chip_seq.size()))),
       d_chip_seq(chip_seq),
       d_bits_per_seq(std::log2(chip_seq.size())),
       d_len_chip_seq(chip_seq[0].size()),


### PR DESCRIPTION
for std::log2 and gr::sync_decimator constructor argument 'decimation', to fix errors on some compilers. This change looks correct to me and compiles cleanly on Clang (llvm 3.4 and 3.6) and GCC 4.9, but you might want to check it to make sure it does what you wanted the original code to do.

The issue at hand is that std::log2 takes a floating-point type, and some compilers will not do implicit type-converstion from size_t to floating.