### PR TITLE
parameterize sample rate for OQPSK_PHY block

### DIFF
--- a/examples/ieee802_15_4_OQPSK_PHY.grc
+++ b/examples/ieee802_15_4_OQPSK_PHY.grc
@@ -1,20 +1,56 @@
 <?xml version='1.0' encoding='ASCII'?>
-<?grc format='1' created='3.7.7'?>
+<?grc format='1' created='3.7.5'?>
 <flow_graph>
-  <timestamp>Tue Nov  4 10:04:33 2014</timestamp>
+  <timestamp>Tue Mar 22 19:55:21 2016</timestamp>
   <block>
-    <key>import</key>
+    <key>options</key>
     <param>
       <key>id</key>
-      <value>import_0</value>
+      <value>ieee802_15_4_oqpsk_phy</value>
     </param>
     <param>
       <key>_enabled</key>
       <value>True</value>
     </param>
     <param>
-      <key>import</key>
-      <value>from math import sin, pi</value>
+      <key>title</key>
+      <value>IEEE802.15.4 OQPSK PHY</value>
+    </param>
+    <param>
+      <key>author</key>
+      <value></value>
+    </param>
+    <param>
+      <key>description</key>
+      <value></value>
+    </param>
+    <param>
+      <key>window_size</key>
+      <value>1280, 1024</value>
+    </param>
+    <param>
+      <key>generate_options</key>
+      <value>hb</value>
+    </param>
+    <param>
+      <key>category</key>
+      <value>IEEE802.15.4</value>
+    </param>
+    <param>
+      <key>run_options</key>
+      <value>prompt</value>
+    </param>
+    <param>
+      <key>run</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>max_nouts</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>realtime_scheduling</key>
+      <value></value>
     </param>
     <param>
       <key>alias</key>
@@ -22,7 +58,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(343, 17)</value>
+      <value>(10, 10)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -33,7 +69,7 @@
     <key>variable</key>
     <param>
       <key>id</key>
-      <value>samp_rate</value>
+      <value>chip_rate</value>
     </param>
     <param>
       <key>_enabled</key>
@@ -41,7 +77,7 @@
     </param>
     <param>
       <key>value</key>
-      <value>4000000</value>
+      <value>2e6</value>
     </param>
     <param>
       <key>alias</key>
@@ -49,7 +85,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(232, 15)</value>
+      <value>(352, 19)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -382,65 +418,6 @@
     <param>
       <key>_coordinate</key>
       <value>(190, 604)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-  </block>
-  <block>
-    <key>digital_clock_recovery_mm_xx</key>
-    <param>
-      <key>id</key>
-      <value>digital_clock_recovery_mm_xx_0</value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>type</key>
-      <value>float</value>
-    </param>
-    <param>
-      <key>omega</key>
-      <value>2</value>
-    </param>
-    <param>
-      <key>gain_omega</key>
-      <value>0.000225</value>
-    </param>
-    <param>
-      <key>mu</key>
-      <value>0.5</value>
-    </param>
-    <param>
-      <key>gain_mu</key>
-      <value>0.03</value>
-    </param>
-    <param>
-      <key>omega_relative_limit</key>
-      <value>0.0002</value>
-    </param>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>minoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>maxoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(770, 589)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1111,53 +1088,29 @@
     </param>
   </block>
   <block>
-    <key>options</key>
+    <key>parameter</key>
     <param>
       <key>id</key>
-      <value>ieee802_15_4_oqpsk_phy</value>
+      <value>samp_rate</value>
     </param>
     <param>
       <key>_enabled</key>
       <value>True</value>
     </param>
     <param>
-      <key>title</key>
-      <value>IEEE802.15.4 OQPSK PHY</value>
-    </param>
-    <param>
-      <key>author</key>
+      <key>label</key>
       <value></value>
     </param>
     <param>
-      <key>description</key>
-      <value></value>
+      <key>value</key>
+      <value>4e6</value>
     </param>
     <param>
-      <key>window_size</key>
-      <value>1280, 1024</value>
+      <key>type</key>
+      <value>eng_float</value>
     </param>
     <param>
-      <key>generate_options</key>
-      <value>hb</value>
-    </param>
-    <param>
-      <key>category</key>
-      <value>IEEE802.15.4</value>
-    </param>
-    <param>
-      <key>run_options</key>
-      <value>prompt</value>
-    </param>
-    <param>
-      <key>run</key>
-      <value>True</value>
-    </param>
-    <param>
-      <key>max_nouts</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>realtime_scheduling</key>
+      <key>short_id</key>
       <value></value>
     </param>
     <param>
@@ -1166,7 +1119,93 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(10, 10)</value>
+      <value>(232, 11)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>import</key>
+    <param>
+      <key>id</key>
+      <value>import_0</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>import</key>
+      <value>from math import sin, pi</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(472, 19)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>digital_clock_recovery_mm_xx</key>
+    <param>
+      <key>id</key>
+      <value>digital_clock_recovery_mm_xx_0</value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>type</key>
+      <value>float</value>
+    </param>
+    <param>
+      <key>omega</key>
+      <value>samp_rate/chip_rate</value>
+    </param>
+    <param>
+      <key>gain_omega</key>
+      <value>0.000225</value>
+    </param>
+    <param>
+      <key>mu</key>
+      <value>0.5</value>
+    </param>
+    <param>
+      <key>gain_mu</key>
+      <value>0.03</value>
+    </param>
+    <param>
+      <key>omega_relative_limit</key>
+      <value>0.0002</value>
+    </param>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(770, 589)</value>
     </param>
     <param>
       <key>_rotation</key>


### PR DESCRIPTION
Changed the sample rate on the 802.15.4 OQPSK_PHY block from constant to a parameter that can be set by the top block. Also changes Omega parameter of MM Clock Recovery block