### PR TITLE
mac/oqpsk phy: add parameters to configure fields within a flowgraph

### DIFF
--- a/grc/ieee802_15_4_access_code_prefixer.xml
+++ b/grc/ieee802_15_4_access_code_prefixer.xml
@@ -5,8 +5,20 @@
 	<key>ieee802_15_4_access_code_prefixer</key>
 	<category>[IEEE802.15.4]</category>
 	<import>import ieee802_15_4</import>
-	<make>ieee802_15_4.access_code_prefixer()</make>
+	<make>ieee802_15_4.access_code_prefixer($pad,$preamble)</make>
 
+        <param>
+		<name>Pad</name>
+		<key>pad</key>
+		<value>0x00</value>
+		<type>hex</type>
+	</param>
+        <param>
+		<name>Preamble</name>
+		<key>preamble</key>
+		<value>0x000000a7</value>
+		<type>hex</type>
+	</param>
 	<sink>
 		<name>in</name>
 		<type>message</type>

--- a/grc/ieee802_15_4_mac.xml
+++ b/grc/ieee802_15_4_mac.xml
@@ -4,7 +4,7 @@
 	<key>ieee802_15_4_mac</key>
 	<category>[IEEE802.15.4]</category>
 	<import>import ieee802_15_4</import>
-	<make>ieee802_15_4.mac($debug)</make>
+	<make>ieee802_15_4.mac($debug,$fcf,$seq_nr,$dst_pan,$dst,$src)</make>
 
 	<param>
 		<name>Debug</name>
@@ -20,6 +20,36 @@
 			<name>Disable</name>
 			<key>False</key>
 		</option>
+	</param>
+	<param>
+		<name>Frame Control</name>
+		<key>fcf</key>
+		<value>0x8841</value>
+		<type>hex</type>
+	</param>
+	<param>
+		<name>Sequence Number</name>
+		<key>seq_nr</key>
+		<value>0</value>
+		<type>hex</type>
+	</param>
+	<param>
+		<name>Destination PAN</name>
+		<key>dst_pan</key>
+		<value>0x1aaa</value>
+		<type>hex</type>
+	</param>
+	<param>
+		<name>Destination Address</name>
+		<key>dst</key>
+		<value>0xffff</value>
+		<type>hex</type>
+	</param>
+	<param>
+		<name>Source Address</name>
+		<key>src</key>
+		<value>0x3344</value>
+		<type>hex</type>
 	</param>
 	<sink>
 		<name>pdu in</name>

--- a/include/ieee802_15_4/access_code_prefixer.h
+++ b/include/ieee802_15_4/access_code_prefixer.h
@@ -28,8 +28,7 @@ class IEEE802_15_4_API access_code_prefixer : virtual public gr::block
 public:
 
 	typedef boost::shared_ptr<access_code_prefixer> sptr;
-	static sptr make();
-
+	static sptr make(int pad=0, int preamble=0x000000a7); // per IEEE 802.15.4
 };
 
 }  // namespace ieee802_15_4

--- a/include/ieee802_15_4/mac.h
+++ b/include/ieee802_15_4/mac.h
@@ -31,7 +31,13 @@ public:
 	virtual float get_packet_error_ratio() = 0;
 	
 	typedef boost::shared_ptr<mac> sptr;
-	static sptr make(bool debug= false);
+	static sptr make(bool debug=false,
+          /* default values for receive sensitivity testing in Zigbee test spec 14-0332-01 */ 
+          int fcf=0x8841,
+          int seq_nr=0,
+          int dst_pan=0x1aaa,
+          int dst=0xffff,
+          int src=0x3344 );
 };
 
 }  // namespace ieee802_11

--- a/lib/access_code_prefixer.cc
+++ b/lib/access_code_prefixer.cc
@@ -26,22 +26,22 @@ class access_code_prefixer_impl : public access_code_prefixer {
 
 	public:
 
-	access_code_prefixer_impl() :
+	access_code_prefixer_impl(int pad, int preamble) :
 			block("access_code_prefixer",
-					gr::io_signature::make(0, 0, 0),
-					gr::io_signature::make(0, 0, 0)) {
+				gr::io_signature::make(0, 0, 0),
+				gr::io_signature::make(0, 0, 0)),
+			d_preamble(preamble) {
 
 	    message_port_register_out(pmt::mp("out"));
 
 	    message_port_register_in(pmt::mp("in"));
 	    set_msg_handler(pmt::mp("in"), boost::bind(&access_code_prefixer_impl::make_frame, this, _1));
+	    buf[0] = pad & 0xFF;
 
-	    buf[0] = 0x00;
-	    buf[1] = 0x00;
-	    buf[2] = 0x00;
-	    buf[3] = 0x00;
-	    buf[4] = 0xA7;
-
+	    for(int i = 4; i > 0; i--) {
+		buf[i] = d_preamble & 0xFF;
+		d_preamble >>= 8;
+	    }
 	}
 
 	~access_code_prefixer_impl() {
@@ -72,13 +72,14 @@ class access_code_prefixer_impl : public access_code_prefixer {
 	}
 
 	private:
-		char buf[256];
+		char		buf[256];
+		unsigned int	d_preamble;
 
 };
 
 access_code_prefixer::sptr
-access_code_prefixer::make() {
-	return gnuradio::get_initial_sptr(new access_code_prefixer_impl());
+access_code_prefixer::make(int pad, int preamble) {
+	return gnuradio::get_initial_sptr(new access_code_prefixer_impl(pad,preamble));
 }
 
 


### PR DESCRIPTION
MAC fields frequently have to be changed when generating test packets. This commit adds parameters to the IEEE802.15.4 MAC and Access Code Prefixer blocks to configure the:
- Frame Control Field
- starting Sequence Number
- Destination PAN
- Destination Address
- Source Address
- Pad (byte typically mangled by transmitter ramp up)
- Preamble
- SFD